### PR TITLE
specify spacy version and include en_core_web_sm link for download

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ scikit-learn
 asyncio
 wordcloud
 matplotlib
-spacy
+spacy==3.7.0
+https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.7.0/en_core_web_sm-3.7.0-py3-none-any.whl


### PR DESCRIPTION
## Description
- Specify `spacy` version to 3.7.0.
- Include the download link for `en_core_web_sm` to load the NLP function of the Spacy module.